### PR TITLE
create Codespace configuration (#3)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.7-5.0
+
+# Install Mono
+RUN sudo apt install gnupg ca-certificates && \
+	sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+	echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list && \
+	sudo apt update && \
+	sudo apt install -y mono-complete && \
+# Install NuGet CLI
+	sudo apt-get update -y && \
+	sudo apt-get install -y nuget
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": " Codespace",
+	"settings": {
+		"workbench.colorTheme": "Default Dark+",
+		"terminal.integrated.defaultProfile.linux": "pwsh"
+	},
+	"extensions": [
+		"eamodio.gitlens",
+		"ms-dotnettools.csharp",
+		"VisualStudioExptTeam.vscodeintellicode",
+		"ms-vscode.powershell",
+		"cschleiden.vscode-github-actions",
+		"redhat.vscode-yaml",
+		"bierner.markdown-preview-github-styles",
+		"ban.spellright",
+		"jmrog.vscode-nuget-package-manager",
+		"coenraads.bracket-pair-colorizer",
+		"vscode-icons-team.vscode-icons",
+		"editorconfig.editorconfig"
+	],
+	"postCreateCommand": "",
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+}
+
+// Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
- ready-to-start GitHub Codespaces configuration with all necessary tooling

- in addition, it provides basic tools for:
  - .NET development
  - GitHub support
  - overall more pleasant VS Code experience
  
The configuration consists of:

- `"settings":` - a list of VS Code settings to be applied automatically after the Codespace container is created (.editorconfig overrides these)
  - `"workbench.colorTheme": "Default Dark+"` - sets the theme of the VS Code workbench to the `Default Dark+` theme
  - `"terminal.integrated.defaultProfile.linux": "pwsh"` - sets the default VS Code terminal to PowerShell Core

- `extensions:` - a list of VS Code extensions that are automatically installed after the Codespace container is created
  - `"eamodio.gitlens"` - provides git information directly inside the code
  - `"ms-dotnettools.csharp"` and `"VisualStudioExptTeam.vscodeintellicode"` - provide basic Visual Studio tooling
  - `"ms-vscode.powershell"` - provides the functionality of Windows PowerShell ISE inside VS Code
  - `"cschleiden.vscode-github-actions"` and `"redhat.vscode-yaml"` - provide YAML and GitHub Actions support
  - `"bierner.markdown-preview-github-styles"` and `"ban.spellright"` - provide assistance with writing Markdown documentation
  - `"jmrog.vscode-nuget-package-manager"` - provides use of the NuGet library through the Command Palette
  - `"coenraads.bracket-pair-colorizer"` - sets different colors for each nested pair of brackets
  - `"vscode-icons-team.vscode-icons"` - provides a huge set of icons for the VS Code explorer
  - `"editorconfig.editorconfig"` - attempts to override user/workspace settings with those in the .editorconfig
  
- `"postCreateCommand"` - is a string of commands separated by `&&` that execute after the container has been built and the source code has been cloned

- `"build"` - declares the Docker configuration that the container would use to run.

- `Dockerfile`:
  - `"mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.7-5.0"` - the Codespace container runs from an Ubuntu 20.04 image with .NET Core SDK installed (`0.201.7` is the latest .NET Core SDK Docker image tagged version)
  - Additional installed tools:
    - Mono
    - NuGet CLI

This GitHub Codespace configuration can also be used locally with the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for VS Code. It automatically creates and runs a Docker container based on the `devcontainer.json` configuration inside the repo, so anyone could work on the project from any computer, without the need to install anything other than VS Code and Docker.
