### PR TITLE
Resolves: Add native GitHub continuous code security and quality analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,46 @@
+name: CodeQL Analysis
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        projects: [
+          'Microsoft.Diagnostics.Tracing\EventSource\EventSource.sln',
+          'Microsoft.Diagnostics.Tracing\TraceEvent\TraceEvent.sln',
+          'System.Numerics\SIMD\System.Numerics.Vectors.SampleCode.sln',
+          'System.Reflection.Metadata\MdDumper\MdDumper.csproj',
+          'WinForms-HDPI\PerMonitorAware\PerMonitorDemo.sln',
+          'WinForms-HDPI\SystemAware\HighDpiDemo.sln'
+        ]
+    steps:
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: csharp
+          queries: security-and-quality
+
+      - name: Build project
+        continue-on-error: true
+        run: |
+          nuget restore ${{ matrix.projects }}
+          msbuild ${{ matrix.projects }} /p:UseSharedCompilation=false
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
- add `codeql-analysis.yml` which automatically enables CodeQL code security and quality scanner. It executes on every push commit, PR, manually and every day at 8:00AM UTC. A scan check can be viewed on commits and PRs. All alerts and fix suggestion can be viewed at **Security** tab -> **Code scanning alerts** -> **CodeQL**

Reolves #70 